### PR TITLE
Fendl update

### DIFF
--- a/convert_fendl.py
+++ b/convert_fendl.py
@@ -8,6 +8,7 @@ import sys
 import zipfile
 from urllib.parse import urljoin
 from textwrap import dedent
+from os import chdir
 
 import openmc.data
 from openmc._utils import download
@@ -42,16 +43,20 @@ parser.add_argument('--libver', choices=['earliest', 'latest'],
                     default='earliest', help="Output HDF5 versioning. Use "
                     "'earliest' for backwards compatibility or 'latest' for "
                     "performance")
-parser.add_argument('-r', '--release', choices=['3.1a', '3.1d', '3.0'],
+parser.add_argument('-r', '--release', choices=['3.1a', '3.1d', '3.0', '2.1'],
                     default='3.1d', help="The nuclear data library release version. "
-                    "The currently supported options are 3.1a and 3.1d")
+                    "The currently supported options are 3.1d, 3.1a, 3.0 and "
+                    "2.1")
 parser.set_defaults(download=True, extract=True)
 args = parser.parse_args()
 
 
 # this could be added as an argument to allow different libraries to be downloaded
 library_name = 'fendl'
-ace_files_dir = Path('-'.join([library_name, args.release, 'ace']))
+cwd = Path.cwd()  
+
+ace_files_dir = cwd.joinpath('-'.join([library_name, args.release, 'ace']))
+zip_path = cwd.joinpath('-'.join([library_name, args.release, 'zips']))
 # the destination is decided after the release is know to avoid putting the release in a folder with a misleading name
 if args.destination is None:
     args.destination = Path('-'.join([library_name, args.release, 'hdf5']))
@@ -78,6 +83,30 @@ release_details = {
         'neutron_files': ace_files_dir.joinpath('ace').glob('*.ace'),
         'compressed_file_size': '0.4 GB',
         'uncompressed_file_size': '2.2 GB'
+    },
+    '2.1': {
+        'base_url': 'https://www-nds.iaea.org/fendl21/fendl21mc/',
+        'files': ['H001mc.zip',  'H002mc.zip',  'H003mc.zip',  'He003mc.zip', 
+                  'He004mc.zip', 'Li006mc.zip', 'Li007mc.zip', 'Be009mc.zip',
+                  'B010mc.zip',  'B011mc.zip',  'C012mc.zip',  'N014mc.zip', 
+                  'N015mc.zip',  'O016mc.zip',  'F019mc.zip',  'Na023mc.zip',
+                  'Mg000mc.zip', 'Al027mc.zip', 'Si028mc.zip', 'Si029mc.zip',
+                  'Si030mc.zip', 'P031mc.zip',  'S000mc.zip',  'Cl035mc.zip', 
+                  'Cl037mc.zip', 'K000mc.zip',  'Ca000mc.zip', 'Ti046mc.zip', 
+                  'Ti047mc.zip', 'Ti048mc.zip', 'Ti049mc.zip', 'Ti050mc.zip', 
+                  'V000mc.zip',  'Cr050mc.zip', 'Cr052mc.zip', 'Cr053mc.zip', 
+                  'Cr054mc.zip', 'Mn055mc.zip', 'Fe054mc.zip', 'Fe056mc.zip', 
+                  'Fe057mc.zip', 'Fe058mc.zip', 'Co059mc.zip', 'Ni058mc.zip', 
+                  'Ni060mc.zip', 'Ni061mc.zip', 'Ni062mc.zip', 'Ni064mc.zip', 
+                  'Cu063mc.zip', 'Cu065mc.zip', 'Ga000mc.zip', 'Zr000mc.zip', 
+                  'Nb093mc.zip', 'Mo092mc.zip', 'Mo094mc.zip', 'Mo095mc.zip', 
+                  'Mo096mc.zip', 'Mo097mc.zip', 'Mo098mc.zip', 'Mo100mc.zip', 
+                  'Sn000mc.zip', 'Ta181mc.zip', 'W182mc.zip',  'W183mc.zip',  
+                  'W184mc.zip',  'W186mc.zip',  'Au197mc.zip', 'Pb206mc.zip', 
+                  'Pb207mc.zip', 'Pb208mc.zip', 'Bi209mc.zip'],
+        'neutron_files': ace_files_dir.glob('*.ace'),
+        'compressed_file_size': '0.4 GB',
+        'uncompressed_file_size': '2.2 GB'
     }
 }
 
@@ -92,19 +121,31 @@ Extracting and processing the data requires {} of additional free disk space.
 
 if args.download:
     print(download_warning)
+
+    if args.release == '2.1':
+        # Older releases have ace files in individual zip files. Create a 
+        # a directory to hold them.
+        zip_path.mkdir(exist_ok=True) 
+        chdir(zip_path)
+
     for f in release_details[args.release]['files']:
         download(urljoin(release_details[args.release]['base_url'], f),
                     as_browser=True, context=ssl._create_unverified_context())
+    chdir(cwd)
 
 # ==============================================================================
 # EXTRACT FILES FROM TGZ
 if args.extract:
+    if args.release == '2.1':
+        chdir(zip_path)
+
     for f in release_details[args.release]['files']:
         # Extract files, the fendl release was compressed using type 9 zip format
         # unfortunatly which is incompatible with the standard python zipfile library
         # therefore the following system command is used
 
         subprocess.call(['unzip', '-o', f, '-d', ace_files_dir])
+    chdir(cwd)
 
 # ==============================================================================
 # GENERATE HDF5 LIBRARY -- NEUTRON FILES
@@ -121,7 +162,7 @@ args.destination.mkdir(parents=True, exist_ok=True)
 
 library = openmc.data.DataLibrary()
 
-warn_k39 = False
+warn_k39 = False 
 
 for filename in sorted(neutron_files):
 

--- a/convert_fendl.py
+++ b/convert_fendl.py
@@ -88,11 +88,22 @@ release_details = {
         }
     },
     '3.1d': {
-        'base_url': 'https://www-nds.iaea.org/fendl/data/neutron/',
-        'files': ['fendl31d-neutron-ace.zip'],
-        'neutron_files': ace_files_dir.joinpath('fendl31d_ACE').glob('*'),
-        'compressed_file_size': 500,
-        'uncompressed_file_size': 3000
+        'neutron':{
+            'base_url': 'https://www-nds.iaea.org/fendl/data/neutron/',
+            'files': ['fendl31d-neutron-ace.zip'],
+            'file_type': 'ace',
+            'ace_files': ace_files_dir.joinpath('fendl31d_ACE').glob('*'),
+            'compressed_file_size': 500,
+            'uncompressed_file_size': 3000
+        },
+        'photon':{
+            'base_url': 'https://www-nds.iaea.org/fendl/data/atom/',
+            'files': ['fendl30-atom-endf.zip'],
+            'file_type': 'endf',
+            'photo_files': endf_files_dir.joinpath('endf').glob('*.txt'),
+            'compressed_file_size': 4,
+            'uncompressed_file_size': 12
+        }
     },
     '3.0': {
         'base_url': 'https://www-nds.iaea.org/fendl30/data/neutron/',

--- a/convert_fendl.py
+++ b/convert_fendl.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import ssl
 import subprocess
 import sys
-import zipfile
 from urllib.parse import urljoin
 from textwrap import dedent
 from os import chdir
@@ -56,7 +55,7 @@ library_name = 'fendl'
 cwd = Path.cwd()  
 
 ace_files_dir = cwd.joinpath('-'.join([library_name, args.release, 'ace']))
-zip_path = cwd.joinpath('-'.join([library_name, args.release, 'zips']))
+download_path = cwd.joinpath('-'.join([library_name, args.release, 'download']))
 # the destination is decided after the release is know to avoid putting the release in a folder with a misleading name
 if args.destination is None:
     args.destination = Path('-'.join([library_name, args.release, 'hdf5']))
@@ -82,7 +81,7 @@ release_details = {
         'files': ['fendl30-neutron-ace.zip'],
         'neutron_files': ace_files_dir.joinpath('ace').glob('*.ace'),
         'compressed_file_size': '0.4 GB',
-        'uncompressed_file_size': '2.2 GB'
+        'uncompressed_file_size': '3.3 GB'
     },
     '2.1': {
         'base_url': 'https://www-nds.iaea.org/fendl21/fendl21mc/',
@@ -105,8 +104,8 @@ release_details = {
                   'W184mc.zip',  'W186mc.zip',  'Au197mc.zip', 'Pb206mc.zip', 
                   'Pb207mc.zip', 'Pb208mc.zip', 'Bi209mc.zip'],
         'neutron_files': ace_files_dir.glob('*.ace'),
-        'compressed_file_size': '0.4 GB',
-        'uncompressed_file_size': '2.2 GB'
+        'compressed_file_size': '0.1 GB',
+        'uncompressed_file_size': '0.6 GB'
     }
 }
 
@@ -125,8 +124,8 @@ if args.download:
     if args.release == '2.1':
         # Older releases have ace files in individual zip files. Create a 
         # a directory to hold them.
-        zip_path.mkdir(exist_ok=True) 
-        chdir(zip_path)
+        download_path.mkdir(exist_ok=True) 
+        chdir(download_path)
 
     for f in release_details[args.release]['files']:
         download(urljoin(release_details[args.release]['base_url'], f),
@@ -137,7 +136,7 @@ if args.download:
 # EXTRACT FILES FROM TGZ
 if args.extract:
     if args.release == '2.1':
-        chdir(zip_path)
+        chdir(download_path)
 
     for f in release_details[args.release]['files']:
         # Extract files, the fendl release was compressed using type 9 zip format

--- a/convert_fendl.py
+++ b/convert_fendl.py
@@ -64,7 +64,8 @@ download_path = cwd.joinpath('-'.join([library_name, args.release, 'download']))
 if args.destination is None:
     args.destination = Path('-'.join([library_name, args.release, 'hdf5']))
 
-# This dictionary contains all the unique information about each release. This can be exstened to accommodated new releases
+# This dictionary contains all the unique information about each release. 
+# This can be extended to accommodate new releases
 release_details = {
     '3.1a': {
         'neutron':{

--- a/convert_fendl.py
+++ b/convert_fendl.py
@@ -8,7 +8,8 @@ import subprocess
 import sys
 from urllib.parse import urljoin
 from textwrap import dedent
-from os import chdir
+import os
+import tempfile
 
 import openmc.data
 from openmc._utils import download
@@ -106,42 +107,65 @@ release_details = {
         }
     },
     '3.0': {
-        'base_url': 'https://www-nds.iaea.org/fendl30/data/neutron/',
-        'files': ['fendl30-neutron-ace.zip'],
-        'neutron_files': ace_files_dir.joinpath('ace').glob('*.ace'),
-        'compressed_file_size': 400,
-        'uncompressed_file_size': 3300
+        'neutron':{
+            'base_url': 'https://www-nds.iaea.org/fendl30/data/neutron/',
+            'files': ['fendl30-neutron-ace.zip'],
+            'file_type': 'ace',
+            'ace_files': ace_files_dir.joinpath('ace').glob('*.ace'),
+            'compressed_file_size': 400,
+            'uncompressed_file_size': 3300
+        },
+        'photon':{
+            'base_url': 'https://www-nds.iaea.org/fendl30/data/atom/',
+            'files': ['fendl30-atom-endf.zip'],
+            'file_type': 'endf',
+            'photo_files': endf_files_dir.joinpath('endf').glob('*.txt'),
+            'compressed_file_size': 4,
+            'uncompressed_file_size': 12
+        }
     },
     '2.1': {
-        'base_url': 'https://www-nds.iaea.org/fendl21/fendl21mc/',
-        'files': ['H001mc.zip',  'H002mc.zip',  'H003mc.zip',  'He003mc.zip', 
-                  'He004mc.zip', 'Li006mc.zip', 'Li007mc.zip', 'Be009mc.zip',
-                  'B010mc.zip',  'B011mc.zip',  'C012mc.zip',  'N014mc.zip', 
-                  'N015mc.zip',  'O016mc.zip',  'F019mc.zip',  'Na023mc.zip',
-                  'Mg000mc.zip', 'Al027mc.zip', 'Si028mc.zip', 'Si029mc.zip',
-                  'Si030mc.zip', 'P031mc.zip',  'S000mc.zip',  'Cl035mc.zip', 
-                  'Cl037mc.zip', 'K000mc.zip',  'Ca000mc.zip', 'Ti046mc.zip', 
-                  'Ti047mc.zip', 'Ti048mc.zip', 'Ti049mc.zip', 'Ti050mc.zip', 
-                  'V000mc.zip',  'Cr050mc.zip', 'Cr052mc.zip', 'Cr053mc.zip', 
-                  'Cr054mc.zip', 'Mn055mc.zip', 'Fe054mc.zip', 'Fe056mc.zip', 
-                  'Fe057mc.zip', 'Fe058mc.zip', 'Co059mc.zip', 'Ni058mc.zip', 
-                  'Ni060mc.zip', 'Ni061mc.zip', 'Ni062mc.zip', 'Ni064mc.zip', 
-                  'Cu063mc.zip', 'Cu065mc.zip', 'Ga000mc.zip', 'Zr000mc.zip', 
-                  'Nb093mc.zip', 'Mo092mc.zip', 'Mo094mc.zip', 'Mo095mc.zip', 
-                  'Mo096mc.zip', 'Mo097mc.zip', 'Mo098mc.zip', 'Mo100mc.zip', 
-                  'Sn000mc.zip', 'Ta181mc.zip', 'W182mc.zip',  'W183mc.zip',  
-                  'W184mc.zip',  'W186mc.zip',  'Au197mc.zip', 'Pb206mc.zip', 
-                  'Pb207mc.zip', 'Pb208mc.zip', 'Bi209mc.zip'],
-        'neutron_files': ace_files_dir.glob('*.ace'),
-        'compressed_file_size': '0.1 GB',
-        'uncompressed_file_size': '0.6 GB'
+        'neutron':{
+            'base_url': 'https://www-nds.iaea.org/fendl21/fendl21mc/',
+            'files': ['H001mc.zip',  'H002mc.zip',  'H003mc.zip',  'He003mc.zip', 
+                    'He004mc.zip', 'Li006mc.zip', 'Li007mc.zip', 'Be009mc.zip',
+                    'B010mc.zip',  'B011mc.zip',  'C012mc.zip',  'N014mc.zip', 
+                    'N015mc.zip',  'O016mc.zip',  'F019mc.zip',  'Na023mc.zip',
+                    'Mg000mc.zip', 'Al027mc.zip', 'Si028mc.zip', 'Si029mc.zip',
+                    'Si030mc.zip', 'P031mc.zip',  'S000mc.zip',  'Cl035mc.zip', 
+                    'Cl037mc.zip', 'K000mc.zip',  'Ca000mc.zip', 'Ti046mc.zip', 
+                    'Ti047mc.zip', 'Ti048mc.zip', 'Ti049mc.zip', 'Ti050mc.zip', 
+                    'V000mc.zip',  'Cr050mc.zip', 'Cr052mc.zip', 'Cr053mc.zip', 
+                    'Cr054mc.zip', 'Mn055mc.zip', 'Fe054mc.zip', 'Fe056mc.zip', 
+                    'Fe057mc.zip', 'Fe058mc.zip', 'Co059mc.zip', 'Ni058mc.zip', 
+                    'Ni060mc.zip', 'Ni061mc.zip', 'Ni062mc.zip', 'Ni064mc.zip', 
+                    'Cu063mc.zip', 'Cu065mc.zip', 'Ga000mc.zip', 'Zr000mc.zip', 
+                    'Nb093mc.zip', 'Mo092mc.zip', 'Mo094mc.zip', 'Mo095mc.zip', 
+                    'Mo096mc.zip', 'Mo097mc.zip', 'Mo098mc.zip', 'Mo100mc.zip', 
+                    'Sn000mc.zip', 'Ta181mc.zip', 'W182mc.zip',  'W183mc.zip',  
+                    'W184mc.zip',  'W186mc.zip',  'Au197mc.zip', 'Pb206mc.zip', 
+                    'Pb207mc.zip', 'Pb208mc.zip', 'Bi209mc.zip'],
+            'file_type': 'ace',
+            'ace_files': ace_files_dir.glob('*.ace'),
+            'compressed_file_size': 100,
+            'uncompressed_file_size': 600
+        },
+        'photon':{
+            'base_url': 'https://www-nds.iaea.org/fendl21/fendl21e/',
+            'files': ['FENDLEP.zip'],
+            'file_type': 'endf',
+            'photo_files': endf_files_dir.glob('*.endf'),
+            'compressed_file_size': 2,
+            'uncompressed_file_size': 5
+        }
     }
 }
 
 compressed_file_size, uncompressed_file_size = 0, 0
 for p in ('neutron', 'photon'):
-    compressed_file_size += release_details[args.release][p]['compressed_file_size']
-    uncompressed_file_size += release_details[args.release][p]['uncompressed_file_size']
+    if p in args.particles:
+        compressed_file_size += release_details[args.release][p]['compressed_file_size']
+        uncompressed_file_size += release_details[args.release][p]['uncompressed_file_size']
 
 download_warning = """
 WARNING: This script will download {} MB of data.
@@ -158,7 +182,7 @@ if args.download:
         # Older releases have ace files in individual zip files. Create a 
         # a directory to hold them.
         download_path.mkdir(exist_ok=True) 
-        chdir(download_path)
+        os.chdir(download_path)
 
     for particle in args.particles:
         particle_details = release_details[args.release][particle]
@@ -166,13 +190,13 @@ if args.download:
             download(urljoin(particle_details['base_url'], f),
                     as_browser=True, context=ssl._create_unverified_context())
     
-    chdir(cwd)
+    os.chdir(cwd)
 
 # ==============================================================================
 # EXTRACT FILES FROM ZIP
 if args.extract:
     if args.release == '2.1':
-        chdir(download_path)
+        os.chdir(download_path)
 
     for particle in args.particles:
         particle_details = release_details[args.release][particle]
@@ -187,7 +211,53 @@ if args.extract:
             # therefore the following system command is used
             subprocess.call(['unzip', '-o', f, '-d', extraction_dir])
     
-    chdir(cwd)
+    os.chdir(cwd)
+
+# ==============================================================================
+# SEPERATE PHOTON ENDF FILE IF NEEDED 
+
+if args.release == '2.1' and 'photon' in args.particles:
+    os.chdir(endf_files_dir)
+    
+    current_file_str = ''
+    last_line_no = 0
+
+    with open('FENDLEP.DAT', 'r') as base_file:
+        header_line = base_file.readline()
+        current_file_str += header_line
+        
+        for line in base_file:
+            
+            current_line_no = int(line.split()[-1])
+            
+            # Start of a new nuclide
+            if current_line_no < last_line_no:
+                # Create a temporary file with the data 
+                new_endf = open('tmp', 'w+')
+                new_endf.write(current_file_str)
+                new_endf.seek(0)
+                
+                # Use the ENDF evaluation method to read the name and 
+                # create a new filename
+                ev = openmc.data.endf.Evaluation(new_endf)
+                new_endf.close()
+                
+                z = ev.target['atomic_number']
+                a = ev.target['mass_number']
+                new_filename = openmc.data.data.ATOMIC_SYMBOL[z]
+                new_filename = new_filename + str(a) + ".endf"
+
+                os.rename('tmp', new_filename)
+                
+                # Need to add a header line if there isn't one at the start of
+                # new nuclide
+                if current_line_no == 1:
+                    current_file_str = header_line
+
+            current_file_str += line
+            last_line_no = current_line_no
+    
+    os.chdir(cwd)
 
 # ==============================================================================
 # GENERATE HDF5 LIBRARY -- NEUTRON FILES
@@ -204,7 +274,8 @@ for particle in args.particles:
     particle_details = release_details[args.release][particle]
     print(f'Release_details: {particle_details}')
     if particle == 'neutron':
-        # Get a list of all ACE files, excluding files ending with _ which are old incorrect files kept in the release for backwards compatability
+        # Get a list of all ACE files, excluding files ending with _ which are 
+        # old incorrect files kept in the release for backwards compatability
         neutron_files = [
             f
             for f in particle_details['ace_files']


### PR DESCRIPTION
This pull request contains changes related to item 6  in our task list and issue 21 in the parent openmc-dev/data repository.

I have included the following in the convert_fendl script:

- Photon data for FENDL-3.1a
- Photon data for FENDL-3.1d
- Neutron and Photon data for FENDL-3.0 
- Neutron and Photon data for FENDL-2.1

I also attempted to add FENDL-2.0 but faced problems because one of the energy laws required was not supported. This was discussed in the comments for the GitHub issue and it was decided that this release could be left out for now. 

I had some issues integrating FENDL-3.0 as K-39 ace file contained 'Inf' values within the data. OpenMC is unable to deal with this and cannot convert the file to HDF5. Although I looked into generating the file using the NJOY functionality built into OpenMC, it was decided that it was best to exclude K-39. I have implemented a check and warning to test if the offending ace file is being processed. 

The FENDL-2.1 release is downloaded as individual ace files as it is not available in the same format as other releases. I thought it was best to create a download folder rather than download them in the current working directory.

Photo ENDF data for FENDL-2.1 is all within a single ENDF file. As such I added functionality which divides the file up into individual ENDF files. 

I have checked to make sure that the HDF5 files are generated for the added releases/particles and have checked the `cross_sections.xml` file contains the required libs. Let me know if you think any other testing is necessary. 